### PR TITLE
Bug fixes

### DIFF
--- a/.changeset/few-peas-unite.md
+++ b/.changeset/few-peas-unite.md
@@ -1,0 +1,5 @@
+---
+'triiiceratops': patch
+---
+
+Clean up five outstanding bugs: 1. Show collection label (#47); 2. Fix loading first manifest in a collection with wrong viewing direction (#46); 3. Only show canvas metadata button when there is additional info and also make it stand out a little more (#45); 4. Normalized image sizes for paged and continuous behaviors (#44); 5. Fix line from annotation label to annoation on canvas so it always attaches to the "inside" side of the label (#43).

--- a/docs/viewer/index.html
+++ b/docs/viewer/index.html
@@ -6,7 +6,7 @@
         <link rel="icon" type="image/svg+xml" href="./favicon.ico" />
         <title>Triiiceratops IIIF Viewer</title>
         <script defer src="https://stats.dflood.org/script.js" data-website-id="014602e8-8f96-4f61-8fd7-02f323a5dfe7"></script>
-      <script type="module" crossorigin src="./assets/index-BrvQqs0i.js"></script>
+      <script type="module" crossorigin src="./assets/index-Da_cWNlN.js"></script>
       <link rel="stylesheet" crossorigin href="./assets/index-BZtsuW-8.css">
     </head>
     <body>

--- a/public/demo-manifests/multi-target-array/manifest.json
+++ b/public/demo-manifests/multi-target-array/manifest.json
@@ -1,0 +1,70 @@
+{
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    "id": "demo-manifests/multi-target-array/manifest.json",
+    "type": "Manifest",
+    "label": {
+        "en": [
+            "Picture of Gottingen taken during the 2019 IIIF Conference"
+        ]
+    },
+    "items": [
+        {
+            "id": "demo-manifests/multi-target-array/canvas/p1",
+            "type": "Canvas",
+            "height": 3024,
+            "width": 4032,
+            "items": [
+                {
+                    "id": "demo-manifests/multi-target-array/page/p1/1",
+                    "type": "AnnotationPage",
+                    "items": [
+                        {
+                            "id": "demo-manifests/multi-target-array/annotation/p0001-image",
+                            "type": "Annotation",
+                            "motivation": "painting",
+                            "body": {
+                                "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen/full/max/0/default.jpg",
+                                "type": "Image",
+                                "format": "image/jpeg",
+                                "height": 3024,
+                                "width": 4032,
+                                "service": [
+                                    {
+                                        "id": "https://iiif.io/api/image/3.0/example/reference/918ecd18c2592080851777620de9bcb5-gottingen",
+                                        "profile": "level1",
+                                        "type": "ImageService3"
+                                    }
+                                ]
+                            },
+                            "target": "demo-manifests/multi-target-array/canvas/p1"
+                        }
+                    ]
+                }
+            ],
+            "annotations": [
+                {
+                    "id": "demo-manifests/multi-target-array/page/p1/2",
+                    "type": "AnnotationPage",
+                    "items": [
+                        {
+                            "id": "demo-manifests/multi-target-array/annotation/p0002-tag",
+                            "type": "Annotation",
+                            "motivation": "tagging",
+                            "body": {
+                                "type": "TextualBody",
+                                "value": "Highlighted detail",
+                                "language": "en",
+                                "format": "text/plain"
+                            },
+                            "target": [
+                                "demo-manifests/multi-target-array/canvas/p1#xywh=1236,906,104,336",
+                                "demo-manifests/multi-target-array/canvas/p1#xywh=1424,913,179,329",
+                                "demo-manifests/multi-target-array/canvas/p1#xywh=1644,960,132,290"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/lib/components/AnnotationOverlay.svelte
+++ b/src/lib/components/AnnotationOverlay.svelte
@@ -38,6 +38,14 @@
         );
     }
 
+    function escapeAttributeValue(value: string): string {
+        if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+            return CSS.escape(value);
+        }
+
+        return value.replace(/(["\\])/g, '\\$1');
+    }
+
     $effect(() => {
         if (
             !viewerState.showAnnotations ||
@@ -78,6 +86,12 @@
         }
 
         const updateCoords = () => {
+            const hoveredAnnotationId = viewerState.hoveredAnnotationId;
+            if (!hoveredAnnotationId) {
+                lineCoords = null;
+                return;
+            }
+
             let root: Document | ShadowRoot = document;
             if (toolbarContainer) {
                 const node = toolbarContainer.getRootNode();
@@ -88,10 +102,10 @@
 
             // Note: The list item ID is now in AnnotationPanel, which must be rendered for this to work
             const listItem = root.getElementById(
-                `annotation-list-item-${viewerState.hoveredAnnotationId}`,
+                `annotation-list-item-${hoveredAnnotationId}`,
             );
-            const visual = root.getElementById(
-                `annotation-visual-${viewerState.hoveredAnnotationId}`,
+            const visual = root.querySelector<HTMLElement>(
+                `[data-annotation-id="${escapeAttributeValue(hoveredAnnotationId)}"]`,
             );
 
             if (listItem && visual) {
@@ -109,12 +123,10 @@
                     // Panel is on right, connect from left edge of list item
                     startX = listRect.left;
                     startY = listRect.top + listRect.height / 2;
-
                 } else {
                     // Panel is on left, connect from right edge of list item
                     startX = listRect.right;
                     startY = listRect.top + listRect.height / 2;
-
                 }
 
                 const endX = visualRect.left + visualRect.width / 2;

--- a/src/lib/components/AnnotationOverlay.svelte
+++ b/src/lib/components/AnnotationOverlay.svelte
@@ -62,8 +62,9 @@
 
     // Connecting line logic
     let toolbarContainer: HTMLElement | undefined = $state();
-    let lineCoords: { x1: number; y1: number; x2: number; y2: number } | null =
-        $state(null);
+    let lines: { x1: number; y1: number; x2: number; y2: number }[] = $state(
+        [],
+    );
     let hoveredAnnotationIsFullCanvas = $derived.by(() => {
         if (!viewerState.hoveredAnnotationId) {
             return false;
@@ -81,14 +82,14 @@
 
     $effect(() => {
         if (!viewerState.hoveredAnnotationId || hoveredAnnotationIsFullCanvas) {
-            lineCoords = null;
+            lines = [];
             return;
         }
 
         const updateCoords = () => {
             const hoveredAnnotationId = viewerState.hoveredAnnotationId;
             if (!hoveredAnnotationId) {
-                lineCoords = null;
+                lines = [];
                 return;
             }
 
@@ -104,18 +105,31 @@
             const listItem = root.getElementById(
                 `annotation-list-item-${hoveredAnnotationId}`,
             );
-            const visual = root.querySelector<HTMLElement>(
-                `[data-annotation-id="${escapeAttributeValue(hoveredAnnotationId)}"]`,
+            const visuals = Array.from(
+                root.querySelectorAll<HTMLElement>(
+                    `[data-annotation-id="${escapeAttributeValue(hoveredAnnotationId)}"]`,
+                ),
             );
 
-            if (listItem && visual) {
+            if (listItem && visuals.length > 0) {
                 const listRect = listItem.getBoundingClientRect();
-                const visualRect = visual.getBoundingClientRect();
 
                 // Determine start point based on panel position (left or right)
-                // We can heuristic this: if list is on right half of screen, connect to its left edge.
-                // If list is on left half, connect to its right edge.
-                const isRightPanel = listRect.left > window.innerWidth / 2;
+                // We find the viewer container's horizontal center to determine if the panel is on its left or right.
+                const viewerEl =
+                    (toolbarContainer &&
+                        toolbarContainer.closest('#triiiceratops-viewer')) ||
+                    root.getElementById('triiiceratops-viewer');
+                let isRightPanel = false;
+                if (viewerEl) {
+                    const viewerRect = viewerEl.getBoundingClientRect();
+                    const viewerCenter = viewerRect.left + viewerRect.width / 2;
+                    isRightPanel =
+                        listRect.left + listRect.width / 2 > viewerCenter;
+                } else {
+                    // Fallback to window-based heuristic if viewer element is not found
+                    isRightPanel = listRect.left > window.innerWidth / 2;
+                }
 
                 let startX, startY;
 
@@ -129,12 +143,14 @@
                     startY = listRect.top + listRect.height / 2;
                 }
 
-                const endX = visualRect.left + visualRect.width / 2;
-                const endY = visualRect.top + visualRect.height / 2;
-
-                lineCoords = { x1: startX, y1: startY, x2: endX, y2: endY };
+                lines = visuals.map((visual) => {
+                    const visualRect = visual.getBoundingClientRect();
+                    const endX = visualRect.left + visualRect.width / 2;
+                    const endY = visualRect.top + visualRect.height / 2;
+                    return { x1: startX, y1: startY, x2: endX, y2: endY };
+                });
             } else {
-                lineCoords = null;
+                lines = [];
             }
         };
 
@@ -149,32 +165,25 @@
     });
 </script>
 
-{#if lineCoords}
+{#if lines.length > 0}
     <svg
         class="fixed inset-0 z-50 pointer-events-none drop-shadow-md text-primary"
         style="width: 100vw; height: 100vh;"
     >
-        <line
-            x1={lineCoords.x1}
-            y1={lineCoords.y1}
-            x2={lineCoords.x2}
-            y2={lineCoords.y2}
-            stroke="currentColor"
-            stroke-width="2"
-        />
-        <!-- Optional: Dots at ends -->
-        <circle
-            cx={lineCoords.x1}
-            cy={lineCoords.y1}
-            r="3"
-            fill="currentColor"
-        />
-        <circle
-            cx={lineCoords.x2}
-            cy={lineCoords.y2}
-            r="3"
-            fill="currentColor"
-        />
+        {#each lines as line, index (`${line.x1}:${line.y1}:${line.x2}:${line.y2}:${index}`)}
+            <line
+                x1={line.x1}
+                y1={line.y1}
+                x2={line.x2}
+                y2={line.y2}
+                stroke="currentColor"
+                stroke-width="2"
+            />
+            <!-- Dot at target end -->
+            <circle cx={line.x2} cy={line.y2} r="3" fill="currentColor" />
+        {/each}
+        <!-- Dot at start (list item) end -->
+        <circle cx={lines[0].x1} cy={lines[0].y1} r="3" fill="currentColor" />
     </svg>
 {/if}
 

--- a/src/lib/components/CanvasInfoPopover.svelte
+++ b/src/lib/components/CanvasInfoPopover.svelte
@@ -45,20 +45,20 @@
 
 	let rendering = $derived(normalizeIiifLinks(json?.rendering, viewerLocale));
 
-    let hasContent = $derived(
-        !!(label || summary || metadata.length > 0 || rendering.length > 0),
+    let hasAdditionalContent = $derived(
+        !!(summary || metadata.length > 0 || rendering.length > 0),
     );
 </script>
 
-{#if hasContent}
+{#if hasAdditionalContent}
     <div class="relative inline-flex">
         <button
-            class="btn btn-circle btn-xs btn-ghost opacity-60 hover:opacity-100"
+            class="btn btn-circle btn-xs btn-ghost text-primary"
             onclick={() => viewerState.toggleCanvasInfo()}
             aria-label={m.canvas_info_tooltip()}
             title={m.canvas_info_tooltip()}
         >
-            <Info size={14} />
+            <Info size={14} weight="bold" />
         </button>
 
         {#if viewerState.showCanvasInfo}
@@ -72,7 +72,7 @@
 
             <!-- Popover -->
             <div
-                class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 bg-base-200 border border-base-300 shadow-xl w-72 max-h-64 overflow-hidden"
+                class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 bg-base-200 border border-base-300 rounded-box shadow-xl w-72 max-h-64 overflow-hidden"
                 role="dialog"
                 aria-label={m.canvas_info()}
             >

--- a/src/lib/components/CollectionPanel.svelte
+++ b/src/lib/components/CollectionPanel.svelte
@@ -41,22 +41,41 @@
         aria-label={m.collection_title()}
     >
         {#if !embedded}
-        <div class="flex items-center justify-between p-4 border-b border-base-300">
-            <div class="flex items-center gap-2 min-w-0">
-                {#if collectionThumbnail}
-                    <img
-                        src={collectionThumbnail}
-                        alt=""
-                        class="w-8 h-8 object-cover rounded-md shrink-0 border border-base-300 bg-base-100"
-                    />
-                {:else}
-                    <Folder size={20} weight="bold" class="shrink-0" />
-                {/if}
-                <h2 class="font-bold text-lg truncate">
-                    {collectionLabel || m.collection_title()}
-                </h2>
+            <div
+                class="flex items-center justify-between p-4 border-b border-base-300"
+            >
+                <div class="flex items-start gap-2 min-w-0">
+                    {#if collectionThumbnail}
+                        <img
+                            src={collectionThumbnail}
+                            alt=""
+                            class="w-8 h-8 object-cover rounded-md shrink-0 border border-base-300 bg-base-100"
+                        />
+                    {:else}
+                        <Folder size={20} weight="bold" class="shrink-0 mt-1" />
+                    {/if}
+                    <h2 class="font-bold text-lg min-w-0 break-words">
+                        {collectionLabel || m.collection_title()}
+                    </h2>
+                </div>
             </div>
-        </div>
+        {:else if collectionLabel || collectionThumbnail}
+            <div class="p-4 border-b border-base-300 bg-base-100/50">
+                <div class="flex items-start gap-3 min-w-0">
+                    {#if collectionThumbnail}
+                        <img
+                            src={collectionThumbnail}
+                            alt=""
+                            class="w-10 h-10 object-cover rounded-md shrink-0 border border-base-300 bg-base-100"
+                        />
+                    {:else}
+                        <Folder size={22} weight="bold" class="shrink-0 mt-1" />
+                    {/if}
+                    <div class="min-w-0 text-sm font-semibold break-words">
+                        {collectionLabel || m.collection_title()}
+                    </div>
+                </div>
+            </div>
         {/if}
 
         <!-- Manifest Count -->

--- a/src/lib/components/DemoHeader.svelte
+++ b/src/lib/components/DemoHeader.svelte
@@ -13,6 +13,7 @@
     import { onMount } from 'svelte';
 
     const isDev = import.meta.env.DEV;
+    const multiTargetDemoManifestUrl = `${import.meta.env.BASE_URL}demo-manifests/multi-target-array/manifest.json`;
 
     const SUGGESTED_MANIFESTS = [
         {
@@ -146,6 +147,10 @@
         {
             label: '0135 Annotating a Specific Point',
             url: 'https://iiif.io/api/cookbook/recipe/0135-annotating-point-in-canvas/manifest.json',
+        },
+        {
+            label: 'Multi-Target Annotation Array',
+            url: multiTargetDemoManifestUrl,
         },
         {
             label: '0202 Start Canvas',

--- a/src/lib/components/OSDViewer.svelte
+++ b/src/lib/components/OSDViewer.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
     import { onMount } from 'svelte';
-    import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+    import { SvelteSet } from 'svelte/reactivity';
     import {
         DEFAULT_MIN_PIXEL_RATIO,
         DEFAULT_MIN_ZOOM_IMAGE_RATIO,
         MOBILE_DRAWER_FALLBACK,
         shouldUseMobileDrawerFallback,
     } from './osdDefaults';
+    import {
+        getCanvasDisplayLayouts,
+        getContinuousTargetPosition,
+        type CanvasDisplayLayout,
+    } from './osdLayout';
     import { resolveTileSources } from './osdTileSources';
     import { parseAnnotations } from '../utils/annotationAdapter';
     import {
@@ -32,6 +37,7 @@
     let viewer: any | undefined = $state.raw();
     let OSD: any | undefined = $state();
     let activeEditAnnotationId = $state<string | null>(null);
+    let continuousLayouts: CanvasDisplayLayout[] = $state.raw([]);
     let readonlyTooltip = $state<{
         id: string;
         text: string;
@@ -642,19 +648,11 @@
 
         // Check if source or layout params actually changed to avoid resetting zoom
         // We include mode and direction in the key because they affect layout even if sources are same
-        const stateKey = `${mode}:${direction}:${JSON.stringify(tileSources)}`;
+        const stateKey = `${mode}:${direction}:${viewerState.preserveCanvasScale}:${JSON.stringify(tileSources)}`;
         if (stateKey === lastTileSourceStr) return;
         lastTileSourceStr = stateKey;
 
-        const isRTL =
-            direction === 'right-to-left' || direction === 'bottom-to-top'; // Treat BTT as reversed flow?
-        // Actually usually BTT is vertical reversed.
-        // For RTL logic in Paged (Side-by-Side), only 'right-to-left' matters.
         const isPagedRTL = direction === 'right-to-left';
-
-        const isVertical =
-            direction === 'top-to-bottom' || direction === 'bottom-to-top';
-        const isBTT = direction === 'bottom-to-top';
 
         // Normalize sources
         const sources = Array.isArray(tileSources)
@@ -710,45 +708,14 @@
                 setTileSourceError(null);
                 const resolvedSources = result.resolved;
 
-                // Build position info for all sources
-                const canvasOrder = new SvelteMap<string, number>();
-                let nextCanvasOrder = 0;
-
-                const allPositions = resolvedSources.map((source, index) => {
-                    let x = 0;
-                    let y = 0;
-                    const canvasId = isPositionedSource(source)
-                        ? source.canvasId
-                        : `canvas-${index}`;
-                    if (!canvasOrder.has(canvasId)) {
-                        canvasOrder.set(canvasId, nextCanvasOrder++);
-                    }
-                    const canvasIndex = canvasOrder.get(canvasId) ?? index;
-                    const localX = isPositionedSource(source) ? source.x : 0;
-                    const localY = isPositionedSource(source) ? source.y : 0;
-                    const localWidth = isPositionedSource(source)
-                        ? source.width
-                        : 1.0;
-                    const actualTileSource = isPositionedSource(source)
-                        ? source.tileSource
-                        : source;
-
-                    if (isVertical) {
-                        const yPos = canvasIndex * (1 + MULTI_CANVAS_GAP);
-                        y = (isBTT ? -yPos : yPos) + localY;
-                        x = localX;
-                    } else {
-                        const xPos = canvasIndex * (1 + MULTI_CANVAS_GAP);
-                        x = (isRTL ? -xPos : xPos) + localX;
-                        y = localY;
-                    }
-                    return {
-                        tileSource: actualTileSource,
-                        x,
-                        y,
-                        width: localWidth,
-                    };
+                const layoutResult = getCanvasDisplayLayouts(resolvedSources, {
+                    mode,
+                    direction,
+                    preserveCanvasScale: viewerState.preserveCanvasScale,
+                    gap: MULTI_CANVAS_GAP,
                 });
+                continuousLayouts = layoutResult.layouts;
+                const allPositions = layoutResult.sources;
 
                 // Only open a window of canvases around the active one for fast initial load.
                 // The rest are added progressively after the viewer opens.
@@ -857,43 +824,12 @@
             const resolvedSources = result.resolved;
 
             if (mode === 'paged') {
-                const offset = 1 + MULTI_CANVAS_GAP;
-                const canvasIds = [
-                    ...new Set(
-                        resolvedSources.map((source, index) =>
-                            isPositionedSource(source)
-                                ? source.canvasId
-                                : `canvas-${index}`,
-                        ),
-                    ),
-                ];
-                const canvasOffsets = new SvelteMap<string, number>();
-
-                canvasIds.forEach((canvasId, index) => {
-                    if (canvasIds.length === 1) {
-                        canvasOffsets.set(canvasId, 0);
-                        return;
-                    }
-
-                    if (index === 0) {
-                        canvasOffsets.set(canvasId, isPagedRTL ? offset : 0);
-                    } else {
-                        canvasOffsets.set(canvasId, isPagedRTL ? 0 : offset);
-                    }
-                });
-
-                const positioned = resolvedSources.map((source) =>
-                    isPositionedSource(source)
-                        ? {
-                              tileSource: source.tileSource,
-                              x:
-                                  source.x +
-                                  (canvasOffsets.get(source.canvasId) ?? 0),
-                              y: source.y,
-                              width: source.width,
-                          }
-                        : source,
-                );
+                const positioned = getCanvasDisplayLayouts(resolvedSources, {
+                    mode,
+                    direction: isPagedRTL ? 'right-to-left' : 'left-to-right',
+                    preserveCanvasScale: viewerState.preserveCanvasScale,
+                    gap: MULTI_CANVAS_GAP,
+                }).sources;
 
                 viewer.open(
                     positioned.length === 1 ? positioned[0] : positioned,
@@ -936,17 +872,12 @@
         const direction = viewerState.viewingDirection;
         const isVertical =
             direction === 'top-to-bottom' || direction === 'bottom-to-top';
-        const isBTT = direction === 'bottom-to-top';
-        const isRTL =
-            direction === 'right-to-left' || direction === 'bottom-to-top';
-
-        const expectedPos = isVertical
-            ? isBTT
-                ? -(currentIndex * (1 + MULTI_CANVAS_GAP))
-                : currentIndex * (1 + MULTI_CANVAS_GAP)
-            : isRTL
-              ? -(currentIndex * (1 + MULTI_CANVAS_GAP))
-              : currentIndex * (1 + MULTI_CANVAS_GAP);
+        const expectedPos = getContinuousTargetPosition(
+            currentIndex,
+            continuousLayouts,
+            direction,
+        );
+        if (expectedPos === null) return;
 
         // Find the world item at the expected position
         const itemCount = viewer.world.getItemCount();

--- a/src/lib/components/OSDViewer.svelte
+++ b/src/lib/components/OSDViewer.svelte
@@ -309,11 +309,13 @@
             // Filter based on visibility
             if (anno.isSearchHit) {
                 // Search hits are always visible
-            } else if (!viewerState.visibleAnnotationIds.has(anno.id)) {
+            } else if (
+                !viewerState.visibleAnnotationIds.has(anno.sourceAnnotationId)
+            ) {
                 continue;
             }
 
-            if (anno.id === activeEditAnnotationId) {
+            if (anno.sourceAnnotationId === activeEditAnnotationId) {
                 continue;
             }
 
@@ -351,7 +353,8 @@
                     );
 
                 results.push({
-                    id: anno.id,
+                    id: anno.renderId,
+                    annotationId: anno.sourceAnnotationId,
                     type: 'RECTANGLE' as const,
                     isFullCanvasTarget: anno.isFullCanvasTarget,
                     rect: {
@@ -403,7 +406,8 @@
                 ]);
 
                 results.push({
-                    id: anno.id,
+                    id: anno.renderId,
+                    annotationId: anno.sourceAnnotationId,
                     type: 'POLYGON' as const,
                     isFullCanvasTarget: anno.isFullCanvasTarget,
                     bounds: {
@@ -433,7 +437,8 @@
                     );
 
                 results.push({
-                    id: anno.id,
+                    id: anno.renderId,
+                    annotationId: anno.sourceAnnotationId,
                     type: 'POINT' as const,
                     isFullCanvasTarget: anno.isFullCanvasTarget,
                     point: {
@@ -977,12 +982,13 @@
 
     <!-- Render annotations -->
     {#each renderedAnnotations as anno (anno.id)}
-        {#if !anno.isFullCanvasTarget || viewerState.hoveredAnnotationId === anno.id}
+        {#if !anno.isFullCanvasTarget || viewerState.hoveredAnnotationId === anno.annotationId}
             {#if anno.type === 'RECTANGLE'}
                 {#if isEditableOverlayAnnotation(anno)}
                     <button
                         type="button"
                         id="annotation-visual-{anno.id}"
+                        data-annotation-id={anno.annotationId}
                         class="absolute border-2 transition-colors cursor-pointer pointer-events-auto {shouldShowOverlayTooltip(
                             anno,
                         )
@@ -1001,13 +1007,17 @@
           height: {anno.rect.height}px;
                  "
                         onclick={(event) =>
-                            requestAnnotationEdit(anno.id, event)}
+                            requestAnnotationEdit(anno.annotationId, event)}
                         onkeydown={(event) =>
-                            handleAnnotationOverlayKeydown(anno.id, event)}
+                            handleAnnotationOverlayKeydown(
+                                anno.annotationId,
+                                event,
+                            )}
                     ></button>
                 {:else}
                     <div
                         id="annotation-visual-{anno.id}"
+                        data-annotation-id={anno.annotationId}
                         class="absolute pointer-events-none"
                         style="
           left: {anno.rect.x}px;
@@ -1031,6 +1041,8 @@
                 {#if isEditableOverlayAnnotation(anno)}
                     <button
                         type="button"
+                        id="annotation-visual-{anno.id}"
+                        data-annotation-id={anno.annotationId}
                         class="absolute pointer-events-auto border-0 bg-transparent p-0 {shouldShowOverlayTooltip(
                             anno,
                         )
@@ -1047,13 +1059,15 @@
           height: {anno.bounds.height}px;
         "
                         onclick={(event) =>
-                            requestAnnotationEdit(anno.id, event)}
+                            requestAnnotationEdit(anno.annotationId, event)}
                         onkeydown={(event) =>
-                            handleAnnotationOverlayKeydown(anno.id, event)}
+                            handleAnnotationOverlayKeydown(
+                                anno.annotationId,
+                                event,
+                            )}
                     >
                         <svg class="absolute inset-0 h-full w-full">
                             <polygon
-                                id="annotation-visual-{anno.id}"
                                 points={anno.points
                                     .map((p: any) => p.join(','))
                                     .join(' ')}
@@ -1066,6 +1080,8 @@
                     </button>
                 {:else}
                     <div
+                        id="annotation-visual-{anno.id}"
+                        data-annotation-id={anno.annotationId}
                         class="absolute pointer-events-none"
                         style="
           left: {anno.bounds.x}px;
@@ -1078,7 +1094,6 @@
                             class="pointer-events-none absolute inset-0 h-full w-full"
                         >
                             <polygon
-                                id="annotation-visual-{anno.id}"
                                 points={anno.points
                                     .map((p: any) => p.join(','))
                                     .join(' ')}
@@ -1099,6 +1114,7 @@
                     <button
                         type="button"
                         id="annotation-visual-{anno.id}"
+                        data-annotation-id={anno.annotationId}
                         class="absolute rounded-full border-2 transition-colors cursor-pointer pointer-events-auto {shouldShowOverlayTooltip(
                             anno,
                         )
@@ -1117,13 +1133,17 @@
 		  height: {POINT_MARKER_SIZE}px;
 		"
                         onclick={(event) =>
-                            requestAnnotationEdit(anno.id, event)}
+                            requestAnnotationEdit(anno.annotationId, event)}
                         onkeydown={(event) =>
-                            handleAnnotationOverlayKeydown(anno.id, event)}
+                            handleAnnotationOverlayKeydown(
+                                anno.annotationId,
+                                event,
+                            )}
                     ></button>
                 {:else}
                     <div
                         id="annotation-visual-{anno.id}"
+                        data-annotation-id={anno.annotationId}
                         class="absolute pointer-events-none"
                         style="
 		  left: {anno.point.x - POINT_MARKER_SIZE / 2}px;

--- a/src/lib/components/SettingsMenu.svelte
+++ b/src/lib/components/SettingsMenu.svelte
@@ -82,6 +82,16 @@
         </label>
     </li>
     <li>
+        <label class="label cursor-pointer py-1">
+            <span class="label-text">Preserve authored canvas scale</span>
+            <input
+                type="checkbox"
+                class="toggle toggle-sm"
+                bind:checked={config.preserveCanvasScale}
+            />
+        </label>
+    </li>
+    <li>
         <label class="label cursor-pointer py-1 gap-2">
             <span class="label-text">Left panel width</span>
             <input

--- a/src/lib/components/TriiiceratopsViewer.svelte
+++ b/src/lib/components/TriiiceratopsViewer.svelte
@@ -216,17 +216,19 @@
         // runs due to internal state changes
         if (canvasId && canvasId !== lastAppliedCanvasId) {
             lastAppliedCanvasId = canvasId;
-            if (
-                internalViewerState.manifestId &&
-                internalViewerState.canvases.length &&
-                !hasCanvas(canvasId)
-            ) {
-                return;
-            }
-            // Only apply if different from current internal state
-            if (canvasId !== internalViewerState.canvasId) {
-                internalViewerState.setCanvas(canvasId);
-            }
+            untrack(() => {
+                if (
+                    internalViewerState.manifestId &&
+                    internalViewerState.canvases.length &&
+                    !hasCanvas(canvasId)
+                ) {
+                    return;
+                }
+                // Only apply if different from current internal state
+                if (canvasId !== internalViewerState.canvasId) {
+                    internalViewerState.setCanvas(canvasId);
+                }
+            });
         }
     });
 
@@ -526,11 +528,9 @@
     // Auto-select initial canvas: prefer start canvas from manifest, then first canvas
     $effect(() => {
         if (
-            canvases &&
             canvases.length > 0 &&
-            !internalViewerState.canvasId &&
-            !manifestData?.isFetching &&
-            !canvasId // Don't auto-select if a canvasId prop is provided
+            currentCanvasIndex < 0 &&
+            !manifestData?.isFetching
         ) {
             const startCanvas = internalViewerState.startCanvasId;
             if (startCanvas) {

--- a/src/lib/components/osdLayout.test.ts
+++ b/src/lib/components/osdLayout.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCanvasDisplayLayouts } from './osdLayout';
+
+const gap = 0.0125;
+
+function source(canvasId: string, width: number, height: number) {
+    return {
+        canvasId,
+        x: 0,
+        y: 0,
+        width: 1,
+        tileSource: { width, height },
+    };
+}
+
+describe('getCanvasDisplayLayouts', () => {
+    it('preserves source-local positions in individuals mode', () => {
+        const result = getCanvasDisplayLayouts(
+            [{ ...source('a', 1000, 2000), x: 0.2, y: 0.3, width: 0.5 }],
+            {
+                mode: 'individuals',
+                direction: 'left-to-right',
+                gap,
+            },
+        );
+
+        expect(result.sources).toEqual([
+            {
+                tileSource: { width: 1000, height: 2000 },
+                x: 0.2,
+                y: 0.3,
+                width: 0.5,
+                canvasId: 'a',
+            },
+        ]);
+    });
+
+    it('preserves authored scale in continuous mode when requested', () => {
+        const result = getCanvasDisplayLayouts(
+            [source('a', 1000, 1000), source('b', 1000, 4000)],
+            {
+                mode: 'continuous',
+                direction: 'left-to-right',
+                preserveCanvasScale: true,
+                gap,
+            },
+        );
+
+        expect(result.sources[0]).toMatchObject({ x: 0, width: 1 });
+        expect(result.sources[1]).toMatchObject({ x: 1 + gap, width: 1 });
+    });
+
+    it('normalizes continuous canvases with different heights', () => {
+        const result = getCanvasDisplayLayouts(
+            [source('a', 1000, 1000), source('b', 1000, 4000)],
+            {
+                mode: 'continuous',
+                direction: 'left-to-right',
+                gap,
+            },
+        );
+
+        expect(result.layouts.map((layout) => layout.height)).toEqual([2.5, 2.5]);
+        expect(result.sources[0]).toMatchObject({ width: 2.5 });
+        expect(result.sources[1]).toMatchObject({ width: 0.625 });
+    });
+
+    it('uses normalized widths plus gap for horizontal continuous offsets', () => {
+        const result = getCanvasDisplayLayouts(
+            [source('a', 1000, 1000), source('b', 1000, 4000)],
+            {
+                mode: 'continuous',
+                direction: 'left-to-right',
+                gap,
+            },
+        );
+
+        expect(result.layouts[1].x).toBeCloseTo(2.5 + gap);
+    });
+
+    it('uses normalized heights plus gap for vertical continuous offsets', () => {
+        const result = getCanvasDisplayLayouts(
+            [source('a', 1000, 1000), source('b', 1000, 4000)],
+            {
+                mode: 'continuous',
+                direction: 'bottom-to-top',
+                gap,
+            },
+        );
+
+        expect(result.layouts[1].y).toBeCloseTo(-(2.5 + gap));
+    });
+
+    it('uses normalized widths for paged placement and preserves RTL ordering', () => {
+        const result = getCanvasDisplayLayouts(
+            [source('a', 1000, 1000), source('b', 1000, 4000)],
+            {
+                mode: 'paged',
+                direction: 'right-to-left',
+                gap,
+            },
+        );
+
+        expect(result.layouts[1].x).toBe(0);
+        expect(result.layouts[0].x).toBeCloseTo(0.625 + gap);
+    });
+
+    it('falls back to current fixed offsets when dimensions are missing', () => {
+        const result = getCanvasDisplayLayouts(
+            [source('a', 1000, 1000), { canvasId: 'b', tileSource: {}, x: 0, y: 0, width: 1 }],
+            {
+                mode: 'continuous',
+                direction: 'left-to-right',
+                gap,
+            },
+        );
+
+        expect(result.sources[1]).toMatchObject({ x: 1 + gap, width: 1 });
+    });
+
+    it('clamps extreme height normalization', () => {
+        const result = getCanvasDisplayLayouts(
+            [
+                source('a', 1000, 10),
+                source('b', 1000, 1000),
+                source('c', 1000, 10000),
+            ],
+            {
+                mode: 'continuous',
+                direction: 'left-to-right',
+                gap,
+            },
+        );
+
+        expect(result.sources[0]).toMatchObject({ width: 4 });
+        expect(result.sources[2]).toMatchObject({ width: 0.25 });
+    });
+});

--- a/src/lib/components/osdLayout.ts
+++ b/src/lib/components/osdLayout.ts
@@ -1,0 +1,225 @@
+export type ViewingMode = 'individuals' | 'paged' | 'continuous';
+
+export type ViewingDirection =
+    | 'left-to-right'
+    | 'right-to-left'
+    | 'top-to-bottom'
+    | 'bottom-to-top';
+
+export interface PositionedTileSource {
+    canvasId?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    tileSource?: unknown;
+}
+
+export interface CanvasDisplayLayout {
+    canvasId: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export interface DisplayPositionedTileSource {
+    tileSource: unknown;
+    x: number;
+    y: number;
+    width: number;
+    canvasId: string;
+}
+
+interface CanvasGroup {
+    canvasId: string;
+    sources: Array<{
+        source: PositionedTileSource | unknown;
+        tileSource: unknown;
+        localX: number;
+        localY: number;
+        localWidth: number;
+        localHeight: number | null;
+    }>;
+    width: number;
+    height: number | null;
+}
+
+interface CanvasLayoutResult {
+    sources: DisplayPositionedTileSource[];
+    layouts: CanvasDisplayLayout[];
+}
+
+function isPositionedSource(source: unknown): source is PositionedTileSource {
+    return !!source && typeof source === 'object' && 'tileSource' in source;
+}
+
+function getDimension(tileSource: unknown, key: 'width' | 'height') {
+    if (!tileSource || typeof tileSource !== 'object') return null;
+    const value = (tileSource as Record<string, unknown>)[key];
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+        ? value
+        : null;
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value));
+}
+
+function median(values: number[]) {
+    const sorted = [...values].sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0
+        ? (sorted[middle - 1] + sorted[middle]) / 2
+        : sorted[middle];
+}
+
+function groupSources(sources: unknown[]): CanvasGroup[] {
+    const groups = new Map<string, CanvasGroup>();
+
+    sources.forEach((source, index) => {
+        const positioned = isPositionedSource(source);
+        const tileSource = positioned ? source.tileSource : source;
+        const canvasId = positioned ? (source.canvasId ?? `canvas-${index}`) : `canvas-${index}`;
+        const localX = positioned ? (source.x ?? 0) : 0;
+        const localY = positioned ? (source.y ?? 0) : 0;
+        const localWidth = positioned ? (source.width ?? 1) : 1;
+        const imageWidth = getDimension(tileSource, 'width');
+        const imageHeight = getDimension(tileSource, 'height');
+        const localHeight = imageWidth && imageHeight ? (localWidth * imageHeight) / imageWidth : null;
+
+        let group = groups.get(canvasId);
+        if (!group) {
+            group = { canvasId, sources: [], width: 0, height: null };
+            groups.set(canvasId, group);
+        }
+
+        group.sources.push({ source, tileSource, localX, localY, localWidth, localHeight });
+        group.width = Math.max(group.width, localX + localWidth);
+        group.height = localHeight === null ? null : Math.max(group.height ?? 0, localY + localHeight);
+    });
+
+    return [...groups.values()];
+}
+
+function useOriginalPositions(groups: CanvasGroup[]): CanvasLayoutResult {
+    return {
+        layouts: groups.map((group) => ({
+            canvasId: group.canvasId,
+            x: 0,
+            y: 0,
+            width: group.width,
+            height: group.height ?? 1,
+        })),
+        sources: groups.flatMap((group) =>
+            group.sources.map(({ tileSource, localX, localY, localWidth }) => ({
+                tileSource,
+                x: localX,
+                y: localY,
+                width: localWidth,
+                canvasId: group.canvasId,
+            })),
+        ),
+    };
+}
+
+export function getCanvasDisplayLayouts(
+    sources: unknown[],
+    options: {
+        mode: ViewingMode;
+        direction: ViewingDirection;
+        preserveCanvasScale?: boolean;
+        gap: number;
+    },
+): CanvasLayoutResult {
+    const groups = groupSources(sources);
+
+    if (options.mode === 'individuals' || groups.length <= 1) {
+        return useOriginalPositions(groups);
+    }
+
+    const canNormalize =
+        !options.preserveCanvasScale &&
+        groups.every((group) => group.height !== null);
+    const referenceHeight = canNormalize
+        ? median(groups.map((group) => group.height as number))
+        : 1;
+    const scaled = groups.map((group) => {
+        const scale = canNormalize
+            ? clamp(referenceHeight / (group.height as number), 0.25, 4)
+            : 1;
+        return {
+            group,
+            scale,
+            width: group.width * scale,
+            height: (group.height ?? 1) * scale,
+            x: 0,
+            y: 0,
+        };
+    });
+
+    if (options.mode === 'continuous') {
+        let offset = 0;
+        const isVertical = options.direction === 'top-to-bottom' || options.direction === 'bottom-to-top';
+        const isReverse = options.direction === 'right-to-left' || options.direction === 'bottom-to-top';
+
+        for (const layout of scaled) {
+            if (isVertical) {
+                layout.y = isReverse ? -offset : offset;
+                offset += (canNormalize ? layout.height : 1) + options.gap;
+            } else {
+                layout.x = isReverse ? -offset : offset;
+                offset += (canNormalize ? layout.width : 1) + options.gap;
+            }
+        }
+    } else if (options.mode === 'paged') {
+        const spreadHeight = Math.max(...scaled.map((layout) => layout.height));
+        const isRTL = options.direction === 'right-to-left';
+
+        scaled.forEach((layout, index) => {
+            const previous = isRTL
+                ? scaled.slice(index + 1)
+                : scaled.slice(0, index);
+            layout.x = previous.reduce(
+                (offset, item) =>
+                    offset + (canNormalize ? item.width : 1) + options.gap,
+                0,
+            );
+            layout.y = (spreadHeight - layout.height) / 2;
+        });
+    }
+
+    return {
+        layouts: scaled.map((layout) => ({
+            canvasId: layout.group.canvasId,
+            x: layout.x,
+            y: layout.y,
+            width: layout.width,
+            height: layout.height,
+        })),
+        sources: scaled.flatMap((layout) =>
+            layout.group.sources.map(({ tileSource, localX, localY, localWidth }) => ({
+                tileSource,
+                x: layout.x + localX * layout.scale,
+                y: layout.y + localY * layout.scale,
+                width: localWidth * layout.scale,
+                canvasId: layout.group.canvasId,
+            })),
+        ),
+    };
+}
+
+export function getContinuousTargetPosition(
+    indexOrCanvasId: number | string,
+    layouts: CanvasDisplayLayout[],
+    direction: ViewingDirection,
+) {
+    const layout =
+        typeof indexOrCanvasId === 'number'
+            ? layouts[indexOrCanvasId]
+            : layouts.find((item) => item.canvasId === indexOrCanvasId);
+
+    if (!layout) return null;
+    return direction === 'top-to-bottom' || direction === 'bottom-to-top'
+        ? layout.y
+        : layout.x;
+}

--- a/src/lib/state/manifests.svelte.ts
+++ b/src/lib/state/manifests.svelte.ts
@@ -13,6 +13,7 @@ export interface ManifestEntry {
 
 export class ManifestsState {
     manifests: Record<string, ManifestEntry> = $state({});
+    private pendingFetches = new Map<string, Promise<void>>();
 
     // User-created annotations (from plugins like annotation editor)
     userAnnotations: SvelteMap<string, any[]> = new SvelteMap();
@@ -69,23 +70,31 @@ export class ManifestsState {
 
     async fetchManifest(manifestId: string, requestConfig?: RequestConfig) {
         const existing = this.manifests[manifestId];
-        if (
-            existing &&
-            (existing.isFetching || existing.json || existing.manifesto)
-        ) {
+        if (existing?.isFetching) {
+            await this.pendingFetches.get(manifestId);
+            return;
+        }
+        if (existing && (existing.json || existing.manifesto)) {
             return; // Already fetched or fetching
         }
 
         this.manifests[manifestId] = { isFetching: true };
 
-        try {
+        const pendingFetch = (async () => {
             const json = await fetchJson(manifestId, requestConfig);
             await this.registerManifest(manifestId, json);
+        })();
+        this.pendingFetches.set(manifestId, pendingFetch);
+
+        try {
+            await pendingFetch;
         } catch (error: any) {
             this.manifests[manifestId] = {
                 error: error.message,
                 isFetching: false,
             };
+        } finally {
+            this.pendingFetches.delete(manifestId);
         }
     }
 

--- a/src/lib/state/manifests.test.ts
+++ b/src/lib/state/manifests.test.ts
@@ -115,6 +115,38 @@ describe('ManifestsState', () => {
 
             expect(mockFetch).not.toHaveBeenCalled();
         });
+
+        it('should wait for an in-flight fetch for the same manifest', async () => {
+            const mockManifest = {
+                id: 'http://example.org/manifest',
+                type: 'Manifest',
+                viewingDirection: 'right-to-left',
+            };
+            let resolveResponse: (response: Response) => void = () => {};
+            mockFetch.mockReturnValueOnce(
+                new Promise((resolve) => {
+                    resolveResponse = resolve;
+                }),
+            );
+
+            const firstFetch = state.fetchManifest('http://example.org/manifest');
+            const secondFetch = state.fetchManifest(
+                'http://example.org/manifest',
+            );
+
+            resolveResponse({
+                ok: true,
+                json: async () => mockManifest,
+            } as Response);
+
+            await Promise.all([firstFetch, secondFetch]);
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(
+                state.manifests['http://example.org/manifest'].json,
+            ).toEqual(mockManifest);
+            expect(parseManifestMock).toHaveBeenCalledWith(mockManifest);
+        });
     });
 
     describe('getCanvases', () => {

--- a/src/lib/state/viewer.behavior.test.ts
+++ b/src/lib/state/viewer.behavior.test.ts
@@ -21,6 +21,10 @@ describe('ViewerState manifest behavior', () => {
     let state: ViewerState;
 
     beforeEach(() => {
+        vi.resetAllMocks();
+        vi.mocked(manifestsState.getAnnotations).mockReturnValue([]);
+        vi.mocked(manifestsState.getCanvases).mockReturnValue([]);
+        vi.mocked(manifestsState.getSequenceCount).mockReturnValue(0);
         state = new ViewerState();
     });
 
@@ -80,6 +84,53 @@ describe('ViewerState manifest behavior', () => {
         await state.setManifestData('manifest-1', { id: 'manifest-1' });
 
         expect(state.viewingDirection).toBe('bottom-to-top');
+    });
+
+    it('prefers raw manifest viewing direction over accessor defaults', async () => {
+        const manifest = {
+            __jsonld: {
+                viewingDirection: 'right-to-left',
+                behavior: ['individuals'],
+            },
+            getViewingDirection: () => 'left-to-right',
+            getBehavior: () => ['individuals'],
+            getSequences: () => [],
+        };
+
+        vi.mocked(manifestsState.getManifest).mockReturnValue(manifest);
+        vi.mocked(manifestsState.getCanvases).mockReturnValue([
+            { id: 'canvas-1' },
+        ]);
+
+        await state.setManifestData('manifest-1', { id: 'manifest-1' });
+
+        expect(state.viewingDirection).toBe('right-to-left');
+    });
+
+    it('uses raw manifest entry viewing direction for fetched v3 manifests', async () => {
+        const manifest = {
+            getViewingDirection: () => 'left-to-right',
+            getBehavior: () => ['individuals'],
+            getSequences: () => [],
+        };
+
+        vi.mocked(manifestsState.getManifest).mockReturnValue(manifest);
+        vi.mocked(manifestsState.getManifestEntry).mockReturnValue({
+            json: {
+                id: 'manifest-1',
+                type: 'Manifest',
+                viewingDirection: 'right-to-left',
+            },
+            manifesto: manifest,
+            isFetching: false,
+        });
+        vi.mocked(manifestsState.getCanvases).mockReturnValue([
+            { id: 'canvas-1' },
+        ]);
+
+        await state.setManifestData('manifest-1', { id: 'manifest-1' });
+
+        expect(state.viewingDirection).toBe('right-to-left');
     });
 
     it('applies the manifest start canvas after fetch-based loading', async () => {
@@ -151,6 +202,34 @@ describe('ViewerState manifest behavior', () => {
             undefined,
         );
         expect(state.manifestId).toBe('http://example.org/manifest/1986');
+    });
+
+    it('does not report a current canvas index until a canvas is selected', () => {
+        vi.mocked(manifestsState.getCanvases).mockReturnValue([
+            { id: 'canvas-1' },
+            { id: 'canvas-2' },
+        ]);
+
+        state.manifestId = 'manifest-1';
+
+        expect(state.currentCanvasIndex).toBe(-1);
+        expect(state.hasNext).toBe(false);
+        expect(state.hasPrevious).toBe(false);
+    });
+
+    it('repairs stale initial canvas selection to the first available canvas', () => {
+        vi.mocked(manifestsState.getCanvases).mockReturnValue([
+            { id: 'canvas-1' },
+            { id: 'canvas-2' },
+        ]);
+
+        state.manifestId = 'manifest-1';
+        state.canvasId = 'stale-canvas';
+
+        (state as any).ensureInitialCanvasSelection();
+
+        expect(state.canvasId).toBe('canvas-1');
+        expect(state.currentCanvasIndex).toBe(0);
     });
 
     it('keeps annotations hidden by default and shows manifest annotations when the panel opens', () => {

--- a/src/lib/state/viewer.behavior.test.ts
+++ b/src/lib/state/viewer.behavior.test.ts
@@ -337,4 +337,16 @@ describe('ViewerState manifest behavior', () => {
         expect([...state.visibleAnnotationIds]).toEqual([]);
         expect(state.annotationVisibilityTouched).toBe(false);
     });
+
+    it('defaults preserveCanvasScale to false in getter and snapshot', () => {
+        expect(state.preserveCanvasScale).toBe(false);
+        expect(state.getSnapshot().preserveCanvasScale).toBe(false);
+    });
+
+    it('reflects preserveCanvasScale config updates in getter and snapshot', () => {
+        state.updateConfig({ preserveCanvasScale: true });
+
+        expect(state.preserveCanvasScale).toBe(true);
+        expect(state.getSnapshot().preserveCanvasScale).toBe(true);
+    });
 });

--- a/src/lib/state/viewer.svelte.ts
+++ b/src/lib/state/viewer.svelte.ts
@@ -317,8 +317,6 @@ export class ViewerState {
             this.selectedSequenceIndex,
         );
 
-        // Auto-initialize canvasId to first canvas if not set
-
         return canvases;
     }
 
@@ -329,7 +327,6 @@ export class ViewerState {
 
     get currentCanvasIndex() {
         if (!this.canvasId) {
-            if (this.canvases.length > 0) return 0;
             return -1;
         }
 
@@ -351,6 +348,10 @@ export class ViewerState {
     }
 
     get hasNext() {
+        if (this.currentCanvasIndex < 0) {
+            return false;
+        }
+
         if (this.viewingMode === 'paged') {
             const groupIndex = this.getCurrentPagedCanvasGroupIndex();
             const groups = getPagedCanvasGroups(
@@ -364,6 +365,10 @@ export class ViewerState {
     }
 
     get hasPrevious() {
+        if (this.currentCanvasIndex < 0) {
+            return false;
+        }
+
         if (this.viewingMode === 'paged') {
             return this.getCurrentPagedCanvasGroupIndex() > 0;
         }
@@ -488,7 +493,6 @@ export class ViewerState {
             this.collectionLabel = getCollectionLabel(json);
             this.collectionThumbnail = getCollectionThumbnail(json) || '';
             this.collectionItems = sortCollectionItems(parseCollection(json));
-            void this.hydrateCollectionItemThumbnails(manifestId);
 
             // Auto-load the first manifest in the collection
             const firstManifest = this.collectionItems.find(
@@ -497,6 +501,7 @@ export class ViewerState {
             if (firstManifest) {
                 await this._loadManifest(firstManifest.id);
             }
+            void this.hydrateCollectionItemThumbnails(manifestId);
             this.dispatchStateChange('manifestchange');
             return;
         }
@@ -542,12 +547,12 @@ export class ViewerState {
     }
 
     private ensureInitialCanvasSelection() {
-        if (this.canvasId) {
+        const canvases = this.canvases;
+        if (!canvases.length) {
             return;
         }
 
-        const canvases = this.canvases;
-        if (!canvases.length) {
+        if (this.canvasId && findCanvasIndexById(canvases, this.canvasId) >= 0) {
             return;
         }
 
@@ -600,6 +605,7 @@ export class ViewerState {
     private _applyManifestSettings(manifestId: string) {
         const manifest = manifestsState.getManifest(manifestId);
         if (!manifest) return;
+        const rawManifest = manifestsState.getManifestEntry(manifestId)?.json;
 
         // 0. Start Canvas (IIIF Presentation 3.0 `start` property)
         try {
@@ -645,24 +651,28 @@ export class ViewerState {
         // 1. Viewing Direction
         let direction: string | null = null;
         try {
-            // Check manifest root first
-            if (manifest.getViewingDirection) {
-                const d = manifest.getViewingDirection();
-                if (d) direction = String(d);
+            // Check raw JSON first (most reliable for IIIF v3)
+            if (rawManifest?.viewingDirection) {
+                direction = rawManifest.viewingDirection;
             }
             if (!direction && manifest.__jsonld) {
                 direction = manifest.__jsonld.viewingDirection;
+            }
+            // Fallback to manifesto accessor
+            if (!direction && manifest.getViewingDirection) {
+                const d = manifest.getViewingDirection();
+                if (d) direction = String(d);
             }
             // Check sequence if not found (IIIF v2)
             if (!direction) {
                 const seq = manifest.getSequences()?.[0];
                 if (seq) {
-                    if (seq.getViewingDirection) {
+                    if (seq.__jsonld) {
+                        direction = seq.__jsonld.viewingDirection;
+                    }
+                    if (!direction && seq.getViewingDirection) {
                         const d = seq.getViewingDirection();
                         if (d) direction = String(d);
-                    }
-                    if (!direction && seq.__jsonld) {
-                        direction = seq.__jsonld.viewingDirection;
                     }
                 }
             }

--- a/src/lib/state/viewer.svelte.ts
+++ b/src/lib/state/viewer.svelte.ts
@@ -24,6 +24,7 @@ import {
     getAnnotationId,
     getCanvasId,
 } from '../utils/iiifIds';
+import { normalizeIiifTargets } from '../utils/iiifTargets';
 import { createPluginId } from '../utils/pluginId';
 import {
     getPagedCanvasGroups,
@@ -1205,18 +1206,6 @@ export class ViewerState {
         return null;
     }
 
-    /** Helper to parse xywh coordinates from an annotation target */
-    private parseXywhSelector(onVal: string | any): number[] | null {
-        const val =
-            typeof onVal === 'string' ? onVal : onVal['@id'] || onVal.id;
-        if (!val) return null;
-        const parts = val.split('#xywh=');
-        if (parts.length < 2) return null;
-        const coords = parts[1].split(',').map(Number);
-        if (coords.length === 4) return coords; // [x, y, w, h]
-        return null;
-    }
-
     /** Helper to unescape HTML-encoded mark tags */
     private decodeMark(str: string): string {
         if (!str) return '';
@@ -1286,26 +1275,30 @@ export class ViewerState {
                     const annotation = resources.find(
                         (r: any) => r['@id'] === annoId || r.id === annoId,
                     );
-                    if (annotation && annotation.on) {
-                        const onVal =
-                            typeof annotation.on === 'string'
-                                ? annotation.on
-                                : annotation.on['@id'] || annotation.on.id;
-                        const cleanOn = onVal.split('#')[0];
-                        const b = this.parseXywhSelector(onVal);
+                    if (!annotation?.on) {
+                        continue;
+                    }
+
+                    for (const target of normalizeIiifTargets(annotation.on)) {
+                        if (!target.canvasId) {
+                            continue;
+                        }
 
                         const cIndex = this.canvases.findIndex(
-                            (c: any) => c.id === cleanOn,
+                            (canvas: any) => canvas.id === target.canvasId,
                         );
 
-                        if (cIndex >= 0) {
-                            if (canvasIndex === -1) {
-                                canvasIndex = cIndex;
-                            }
-                            if (b) {
-                                allBounds.push(b);
-                                if (!bounds) bounds = b;
-                            }
+                        if (cIndex < 0) {
+                            continue;
+                        }
+
+                        if (canvasIndex === -1) {
+                            canvasIndex = cIndex;
+                        }
+
+                        if (target.xywh) {
+                            allBounds.push(target.xywh);
+                            if (!bounds) bounds = target.xywh;
                         }
                     }
                 }
@@ -1327,17 +1320,26 @@ export class ViewerState {
             }
         } else if (resources.length > 0) {
             for (const res of resources) {
-                const onVal =
-                    typeof res.on === 'string'
-                        ? res.on
-                        : res.on['@id'] || res.on.id;
-                const cleanOn = onVal.split('#')[0];
-                const bounds = this.parseXywhSelector(onVal);
+                const normalizedTargets = normalizeIiifTargets(res.on);
+                const firstTarget = normalizedTargets.find(
+                    (target) => target.canvasId,
+                );
+                if (!firstTarget?.canvasId) {
+                    continue;
+                }
 
                 const canvasIndex = this.canvases.findIndex(
-                    (c: any) => c.id === cleanOn,
+                    (canvas: any) => canvas.id === firstTarget.canvasId,
                 );
                 if (canvasIndex >= 0) {
+                    const boundsArray = normalizedTargets
+                        .map((target) => target.xywh)
+                        .filter(
+                            (
+                                bounds,
+                            ): bounds is [number, number, number, number] =>
+                                bounds !== null,
+                        );
                     const group = this.getOrCreateCanvasGroup(
                         resultsByCanvas,
                         canvasIndex,
@@ -1349,8 +1351,8 @@ export class ViewerState {
                                 ? res.resource.chars
                                 : res.chars || '',
                         ),
-                        bounds,
-                        allBounds: bounds ? [bounds] : [],
+                        bounds: boundsArray[0] || null,
+                        allBounds: boundsArray,
                     });
                 }
             }
@@ -1426,34 +1428,15 @@ export class ViewerState {
         for (const item of items) {
             const annoId = item.id || item['@id'];
 
-            // v2 items can legitimately point at multiple targets for one hit.
-            const targets = Array.isArray(item.target)
-                ? item.target
-                : [item.target];
             let canvasIndex = -1;
             let bounds: number[] | null = null;
             const allBounds: number[][] = [];
 
-            for (const target of targets) {
-                let targetStr: string | null = null;
+            for (const target of normalizeIiifTargets(item.target)) {
+                if (!target.canvasId) continue;
 
-                if (typeof target === 'string') {
-                    targetStr = target;
-                } else if (target && typeof target === 'object') {
-                    targetStr = target.id || target['@id'] || null;
-                    if (!targetStr && target.source) {
-                        targetStr =
-                            typeof target.source === 'string'
-                                ? target.source
-                                : target.source.id || target.source['@id'];
-                    }
-                }
-
-                if (!targetStr) continue;
-
-                const cleanTarget = targetStr.split('#')[0];
                 const targetCanvasIndex = this.canvases.findIndex(
-                    (c: any) => c.id === cleanTarget,
+                    (canvas: any) => canvas.id === target.canvasId,
                 );
                 if (targetCanvasIndex < 0) continue;
 
@@ -1461,10 +1444,9 @@ export class ViewerState {
                     canvasIndex = targetCanvasIndex;
                 }
 
-                const targetBounds = this.parseXywhSelector(targetStr);
-                if (targetBounds) {
-                    allBounds.push(targetBounds);
-                    if (!bounds) bounds = targetBounds;
+                if (target.xywh) {
+                    allBounds.push(target.xywh);
+                    if (!bounds) bounds = target.xywh;
                 }
             }
 

--- a/src/lib/state/viewer.svelte.ts
+++ b/src/lib/state/viewer.svelte.ts
@@ -61,6 +61,7 @@ export interface ViewerStateSnapshot {
         | 'right-to-left'
         | 'top-to-bottom'
         | 'bottom-to-top';
+    preserveCanvasScale: boolean;
     galleryPosition: { x: number; y: number };
     gallerySize: { width: number; height: number };
 }
@@ -167,6 +168,9 @@ export class ViewerState {
     get showZoomControls() {
         return this.config.showZoomControls ?? true;
     }
+    get preserveCanvasScale() {
+        return this.config.preserveCanvasScale ?? false;
+    }
 
     get galleryFixedHeight() {
         return this.config.gallery?.fixedHeight ?? 120;
@@ -248,6 +252,7 @@ export class ViewerState {
             dockSide: this.dockSide,
             viewingMode: this.viewingMode,
             viewingDirection: this.viewingDirection,
+            preserveCanvasScale: this.preserveCanvasScale,
             galleryPosition: this.galleryPosition,
             gallerySize: this.gallerySize,
         };

--- a/src/lib/types/config/viewer.ts
+++ b/src/lib/types/config/viewer.ts
@@ -50,6 +50,15 @@ export interface ViewerConfig {
     pagedViewOffset?: boolean;
 
     /**
+     * Preserve authored IIIF canvas scale in multi-canvas OpenSeadragon layouts.
+     * When false, paged and continuous modes normalize canvas display heights
+     * so unusually wide/tall canvases remain readable and comparable.
+     * Single-canvas individuals mode is unchanged.
+     * @default false
+     */
+    preserveCanvasScale?: boolean;
+
+    /**
      * Whether to show the zoom controls in the canvas navigation.
      * @default true
      */

--- a/src/lib/utils/annotationAdapter.test.ts
+++ b/src/lib/utils/annotationAdapter.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { isFullCanvasAnnotation, parseAnnotation } from './annotationAdapter';
+import {
+    isFullCanvasAnnotation,
+    parseAnnotation,
+    parseAnnotations,
+} from './annotationAdapter';
 
 describe('annotationAdapter', () => {
     describe('parseAnnotation', () => {
@@ -244,6 +248,105 @@ describe('annotationAdapter', () => {
             expect(parseAnnotation(annotation, 9)?.coordinateSpace).toBe(
                 'canvas',
             );
+        });
+
+        it('should expand multiple target fragments into multiple render entries', () => {
+            const annotation = {
+                id: 'multi-fragment',
+                target: [
+                    'http://example.org/canvas1#xywh=10,20,100,200',
+                    'http://example.org/canvas1#xywh=30,40,50,60',
+                    'http://example.org/canvas1#xywh=70,80,90,100',
+                ],
+                __triiiceratopsCanvas: {
+                    id: 'http://example.org/canvas1',
+                    width: 800,
+                    height: 600,
+                },
+                __triiiceratopsAnnotationOrigin: 'manifest',
+            };
+
+            const parsed = parseAnnotations([annotation]);
+
+            expect(parsed).toHaveLength(3);
+            expect(parsed.map((entry) => entry.renderId)).toEqual([
+                'multi-fragment::0',
+                'multi-fragment::1',
+                'multi-fragment::2',
+            ]);
+            expect(parsed.map((entry) => entry.sourceAnnotationId)).toEqual([
+                'multi-fragment',
+                'multi-fragment',
+                'multi-fragment',
+            ]);
+            expect(parsed.map((entry) => entry.geometry)).toEqual([
+                {
+                    type: 'RECTANGLE',
+                    x: 10,
+                    y: 20,
+                    w: 100,
+                    h: 200,
+                },
+                {
+                    type: 'RECTANGLE',
+                    x: 30,
+                    y: 40,
+                    w: 50,
+                    h: 60,
+                },
+                {
+                    type: 'RECTANGLE',
+                    x: 70,
+                    y: 80,
+                    w: 90,
+                    h: 100,
+                },
+            ]);
+            expect(parseAnnotation(annotation, 10)?.geometry).toEqual({
+                type: 'RECTANGLE',
+                x: 10,
+                y: 20,
+                w: 100,
+                h: 200,
+            });
+        });
+
+        it('should skip invalid targets while keeping valid multi-target entries', () => {
+            const annotation = {
+                id: 'mixed-fragment',
+                target: [
+                    'http://example.org/canvas1',
+                    'http://example.org/canvas1#xywh=5,6,7,8',
+                    { source: 'http://example.org/canvas1' },
+                    'http://example.org/canvas1#xywh=10,11,12,13',
+                ],
+                __triiiceratopsCanvas: {
+                    id: 'http://example.org/canvas1',
+                    width: 800,
+                    height: 600,
+                },
+                __triiiceratopsAnnotationOrigin: 'manifest',
+            };
+
+            const parsed = parseAnnotations([annotation]);
+
+            expect(parsed).toHaveLength(2);
+            expect(parsed.map((entry) => entry.geometry)).toEqual([
+                {
+                    type: 'RECTANGLE',
+                    x: 5,
+                    y: 6,
+                    w: 7,
+                    h: 8,
+                },
+                {
+                    type: 'RECTANGLE',
+                    x: 10,
+                    y: 11,
+                    w: 12,
+                    h: 13,
+                },
+            ]);
         });
     });
 });

--- a/src/lib/utils/annotationAdapter.ts
+++ b/src/lib/utils/annotationAdapter.ts
@@ -1,8 +1,18 @@
+import {
+    extractIiifTargetId,
+    getIiifCanvasId,
+    normalizeIiifTargets,
+    parseIiifXywh,
+} from './iiifTargets';
+
 /**
  * Parsed annotation interface for custom rendering
  */
 export interface ParsedAnnotation {
     id: string;
+    renderId: string;
+    sourceAnnotationId: string;
+    geometryIndex: number;
     geometry: RectangleGeometry | PolygonGeometry | PointGeometry;
     coordinateSpace: 'canvas' | 'image';
     isFullCanvasTarget: boolean;
@@ -61,17 +71,13 @@ function getAnnotationId(anno: any): string {
 function parseXywh(
     targetStr: string,
 ): { x: number; y: number; w: number; h: number } | null {
-    if (!targetStr) return null;
-    // Match xywh= optionally followed by "pixel:" and handle floats
-    const match = targetStr.match(
-        /xywh=(?:pixel:)?([\d.]+),([\d.]+),([\d.]+),([\d.]+)/,
-    );
-    if (match) {
+    const xywh = parseIiifXywh(targetStr);
+    if (xywh) {
         return {
-            x: parseFloat(match[1]),
-            y: parseFloat(match[2]),
-            w: parseFloat(match[3]),
-            h: parseFloat(match[4]),
+            x: xywh[0],
+            y: xywh[1],
+            w: xywh[2],
+            h: xywh[3],
         };
     }
     return null;
@@ -80,80 +86,51 @@ function parseXywh(
 /**
  * Extract target geometry from various annotation formats
  */
-function extractGeometry(
+function extractGeometries(
     annotation: any,
-): RectangleGeometry | PolygonGeometry | PointGeometry | null {
-    // Try to find SVG selector first
-    const svgSelector = findSvgSelector(annotation);
-    if (svgSelector) {
-        return convertSvgToPolygon(svgSelector);
+): Array<RectangleGeometry | PolygonGeometry | PointGeometry> {
+    const target = getAnnotationTarget(annotation);
+    const geometries: Array<
+        RectangleGeometry | PolygonGeometry | PointGeometry
+    > = [];
+
+    for (const normalizedTarget of normalizeIiifTargets(target)) {
+        for (const selector of normalizedTarget.selectors) {
+            const svgSelector = extractSvgValue(selector);
+            if (svgSelector) {
+                const polygon = convertSvgToPolygon(svgSelector);
+                if (polygon) {
+                    geometries.push(polygon);
+                }
+            }
+
+            const point = extractPointFromSelector(selector);
+            if (point) {
+                geometries.push(point);
+            }
+        }
+
+        if (normalizedTarget.xywh) {
+            geometries.push({
+                type: 'RECTANGLE',
+                x: normalizedTarget.xywh[0],
+                y: normalizedTarget.xywh[1],
+                w: normalizedTarget.xywh[2],
+                h: normalizedTarget.xywh[3],
+            });
+        }
     }
 
-    const pointSelector = findPointSelector(annotation);
-    if (pointSelector) {
-        return pointSelector;
-    }
-
-    // Extract xywh from target
-    const xywh = extractXywhFromTarget(annotation);
-    if (xywh) {
-        return {
-            type: 'RECTANGLE',
-            x: xywh.x,
-            y: xywh.y,
-            w: xywh.w,
-            h: xywh.h,
-        };
+    if (geometries.length > 0) {
+        return geometries;
     }
 
     const canvasRect = extractWholeCanvasGeometry(annotation);
     if (canvasRect) {
-        return canvasRect;
+        return [canvasRect];
     }
 
-    return null;
-}
-
-function findPointSelector(annotation: any): PointGeometry | null {
-    if (typeof annotation.getTarget === 'function') {
-        const rawTarget =
-            annotation.__jsonld?.on || annotation.__jsonld?.target;
-        if (rawTarget) {
-            return extractPointFromTarget(rawTarget);
-        }
-    }
-
-    const target = annotation.target || annotation.on;
-    if (target) {
-        return extractPointFromTarget(target);
-    }
-
-    return null;
-}
-
-function extractPointFromTarget(target: any): PointGeometry | null {
-    if (!target) return null;
-
-    if (Array.isArray(target)) {
-        for (const item of target) {
-            const point = extractPointFromTarget(item);
-            if (point) return point;
-        }
-        return null;
-    }
-
-    if (target.selector) {
-        const selectors = Array.isArray(target.selector)
-            ? target.selector
-            : [target.selector];
-
-        for (const selector of selectors) {
-            const point = extractPointFromSelector(selector);
-            if (point) return point;
-        }
-    }
-
-    return target.source ? extractPointFromTarget(target.source) : null;
+    return [];
 }
 
 function extractPointFromSelector(selector: any): PointGeometry | null {
@@ -197,25 +174,12 @@ function getAnnotationTarget(annotation: any): any {
 }
 
 function getTargetId(target: any): string | null {
-    if (!target) return null;
-
-    if (typeof target === 'string') {
-        return target.split('#')[0];
-    }
-
-    if (Array.isArray(target)) {
-        for (const item of target) {
-            const id = getTargetId(item);
-            if (id) return id;
-        }
+    const targetId = extractIiifTargetId(target);
+    if (!targetId) {
         return null;
     }
 
-    if (target.source) {
-        return getTargetId(target.source);
-    }
-
-    return target.id || target['@id'] || null;
+    return getIiifCanvasId(targetId) || targetId;
 }
 
 function hasTargetSelector(target: any): boolean {
@@ -499,91 +463,6 @@ function generateCirclePoints(
 /**
  * Extract xywh from annotation target (multiple formats)
  */
-function extractXywhFromTarget(
-    annotation: any,
-): { x: number; y: number; w: number; h: number } | null {
-    // Try Manifesto getTarget method
-    if (typeof annotation.getTarget === 'function') {
-        const target = annotation.getTarget();
-        if (typeof target === 'string' && target.includes('xywh=')) {
-            return parseXywh(target);
-        }
-        // Check raw JSON as fallback
-        const rawOn = annotation.__jsonld?.on;
-        if (rawOn) {
-            const xywh = extractXywhFromRawTarget(rawOn);
-            if (xywh) return xywh;
-        }
-    }
-
-    // Check raw annotation formats (v2 and v3)
-    const target = annotation.target || annotation.on;
-    if (target) {
-        return extractXywhFromRawTarget(target);
-    }
-
-    return null;
-}
-
-/**
- * Extract xywh from raw target object/array
- */
-function extractXywhFromRawTarget(
-    target: any,
-): { x: number; y: number; w: number; h: number } | null {
-    if (!target) return null;
-
-    // Handle arrays
-    if (Array.isArray(target)) {
-        for (const t of target) {
-            const xywh = extractXywhFromRawTarget(t);
-            if (xywh) return xywh;
-        }
-    }
-
-    // Handle string targets with xywh
-    if (typeof target === 'string' && target.includes('xywh=')) {
-        return parseXywh(target);
-    }
-
-    // Handle object with selector
-    if (target.selector) {
-        const sel = target.selector;
-
-        // Handle array of selectors
-        if (Array.isArray(sel)) {
-            // Prefer FragmentSelector
-            const fragment = sel.find(
-                (s) =>
-                    s.type === 'FragmentSelector' &&
-                    s.value &&
-                    s.value.includes('xywh='),
-            );
-            if (fragment) return parseXywh(fragment.value);
-
-            // Or generic
-            const anyXywh = sel.find(
-                (s) => s.value && s.value.includes('xywh='),
-            );
-            if (anyXywh) return parseXywh(anyXywh.value);
-
-            return null;
-        }
-
-        const item = sel.item || sel;
-
-        if (
-            item.value &&
-            typeof item.value === 'string' &&
-            item.value.includes('xywh=')
-        ) {
-            return parseXywh(item.value);
-        }
-    }
-
-    return null;
-}
-
 /**
  * Extract annotation body content (text, label, etc)
  */
@@ -678,6 +557,42 @@ export function extractBody(annotation: any): {
     return bodies;
 }
 
+function createRenderId(annotationId: string, geometryIndex: number): string {
+    return `${annotationId}::${geometryIndex}`;
+}
+
+function buildParsedAnnotations(
+    annotation: any,
+    index: number,
+    isSearchHit: boolean,
+): ParsedAnnotation[] {
+    const id = getAnnotationId(annotation) || `anno-${index}`;
+    const geometries = extractGeometries(annotation);
+    const isFullCanvasTarget = isFullCanvasAnnotation(annotation);
+    const coordinateSpace = resolveCoordinateSpace(
+        annotation,
+        isFullCanvasTarget,
+    );
+
+    if (!geometries.length) {
+        return [];
+    }
+
+    const body = extractBody(annotation);
+
+    return geometries.map((geometry, geometryIndex) => ({
+        id,
+        renderId: createRenderId(id, geometryIndex),
+        sourceAnnotationId: id,
+        geometryIndex,
+        geometry,
+        coordinateSpace,
+        isFullCanvasTarget,
+        body,
+        isSearchHit,
+    }));
+}
+
 /**
  * Parse Manifesto/IIIF annotation to internal format
  */
@@ -686,29 +601,7 @@ export function parseAnnotation(
     index: number,
     isSearchHit: boolean = false,
 ): ParsedAnnotation | null {
-    const id = getAnnotationId(annotation) || `anno-${index}`;
-    const geometry = extractGeometry(annotation);
-    const isFullCanvasTarget = isFullCanvasAnnotation(annotation);
-    const coordinateSpace = resolveCoordinateSpace(
-        annotation,
-        isFullCanvasTarget,
-    );
-
-    // Skip annotations without geometry
-    if (!geometry) {
-        return null;
-    }
-
-    const body = extractBody(annotation);
-
-    return {
-        id,
-        geometry,
-        coordinateSpace,
-        isFullCanvasTarget,
-        body,
-        isSearchHit,
-    };
+    return buildParsedAnnotations(annotation, index, isSearchHit)[0] ?? null;
 }
 
 /**
@@ -719,9 +612,9 @@ export function parseAnnotations(
     searchHitIds: Set<string> = new Set(),
 ): ParsedAnnotation[] {
     return annotations
-        .map((anno, idx) => {
+        .flatMap((anno, idx) => {
             const isSearchHit = searchHitIds.has(getAnnotationId(anno));
-            return parseAnnotation(anno, idx, isSearchHit);
+            return buildParsedAnnotations(anno, idx, isSearchHit);
         })
         .filter((anno) => anno !== null) as ParsedAnnotation[];
 }

--- a/src/lib/utils/contentState.test.ts
+++ b/src/lib/utils/contentState.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseContentState } from './contentState';
+
+describe('contentState', () => {
+    it('parses target canvas ids and xywh regions via shared IIIF helpers', () => {
+        const payload = {
+            id: 'annotation-1',
+            type: 'Annotation',
+            target: 'https://example.org/canvas/1#xywh=1236,906,104,336',
+            partOf: {
+                id: 'https://example.org/manifest/1',
+            },
+        };
+        const value = Buffer.from(JSON.stringify(payload), 'utf8')
+            .toString('base64')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/g, '');
+
+        expect(parseContentState(value)).toEqual({
+            manifestId: 'https://example.org/manifest/1',
+            canvasId: 'https://example.org/canvas/1',
+            region: {
+                x: 1236,
+                y: 906,
+                width: 104,
+                height: 336,
+            },
+        });
+    });
+});

--- a/src/lib/utils/contentState.ts
+++ b/src/lib/utils/contentState.ts
@@ -1,3 +1,5 @@
+import { getIiifCanvasId, parseIiifXywh } from './iiifTargets';
+
 export type CanvasRegion = {
     x: number;
     y: number;
@@ -27,17 +29,16 @@ function decodeContentState(value: string): string {
 function parseTarget(
     target: string,
 ): Pick<ContentStateTarget, 'canvasId' | 'region'> {
-    const [canvasId, fragment] = target.split('#');
-    const regionMatch = fragment?.match(/xywh=(\d+),(\d+),(\d+),(\d+)/);
+    const xywh = parseIiifXywh(target);
 
     return {
-        canvasId: canvasId || undefined,
-        region: regionMatch
+        canvasId: getIiifCanvasId(target) || undefined,
+        region: xywh
             ? {
-                  x: Number(regionMatch[1]),
-                  y: Number(regionMatch[2]),
-                  width: Number(regionMatch[3]),
-                  height: Number(regionMatch[4]),
+                  x: xywh[0],
+                  y: xywh[1],
+                  width: xywh[2],
+                  height: xywh[3],
               }
             : undefined,
     };

--- a/src/lib/utils/iiifTargets.ts
+++ b/src/lib/utils/iiifTargets.ts
@@ -1,0 +1,135 @@
+export type IiifTargetBounds = [number, number, number, number];
+
+export type NormalizedIiifTarget = {
+    raw: unknown;
+    targetId: string | null;
+    canvasId: string | null;
+    selectors: any[];
+    xywh: IiifTargetBounds | null;
+};
+
+export function parseIiifXywh(value: string): IiifTargetBounds | null {
+    if (!value) return null;
+
+    const match = value.match(
+        /xywh=(?:pixel:)?([\d.]+),([\d.]+),([\d.]+),([\d.]+)/,
+    );
+    if (!match) {
+        return null;
+    }
+
+    return [
+        Number(match[1]),
+        Number(match[2]),
+        Number(match[3]),
+        Number(match[4]),
+    ];
+}
+
+export function getIiifCanvasId(targetId: string): string | null {
+    const [canvasId] = targetId.split('#');
+    return canvasId || null;
+}
+
+export function extractIiifTargetId(target: unknown): string | null {
+    if (!target) return null;
+
+    if (typeof target === 'string') {
+        return target;
+    }
+
+    if (Array.isArray(target)) {
+        for (const item of target) {
+            const targetId = extractIiifTargetId(item);
+            if (targetId) {
+                return targetId;
+            }
+        }
+        return null;
+    }
+
+    if (typeof target !== 'object') {
+        return null;
+    }
+
+    const record = target as Record<string, any>;
+    if (typeof record.id === 'string') {
+        return record.id;
+    }
+
+    if (typeof record['@id'] === 'string') {
+        return record['@id'];
+    }
+
+    if (record.source) {
+        return extractIiifTargetId(record.source);
+    }
+
+    return null;
+}
+
+function normalizeIiifSelectors(selector: unknown): any[] {
+    if (!selector) return [];
+
+    if (Array.isArray(selector)) {
+        return selector.flatMap((item) => normalizeIiifSelectors(item));
+    }
+
+    if (typeof selector !== 'object') {
+        return [];
+    }
+
+    const record = selector as Record<string, any>;
+    if (record.item) {
+        return normalizeIiifSelectors(record.item);
+    }
+
+    return [record];
+}
+
+function findSelectorXywh(selectors: any[]): IiifTargetBounds | null {
+    const preferredSelector = selectors.find(
+        (selector) =>
+            selector?.type === 'FragmentSelector' &&
+            typeof selector?.value === 'string' &&
+            selector.value.includes('xywh='),
+    );
+    if (preferredSelector) {
+        return parseIiifXywh(preferredSelector.value);
+    }
+
+    const fallbackSelector = selectors.find(
+        (selector) =>
+            typeof selector?.value === 'string' &&
+            selector.value.includes('xywh='),
+    );
+
+    return fallbackSelector ? parseIiifXywh(fallbackSelector.value) : null;
+}
+
+export function normalizeIiifTargets(target: unknown): NormalizedIiifTarget[] {
+    if (!target) return [];
+
+    if (Array.isArray(target)) {
+        return target.flatMap((item) => normalizeIiifTargets(item));
+    }
+
+    const targetId = extractIiifTargetId(target);
+    const selectors =
+        typeof target === 'object' && target && 'selector' in target
+            ? normalizeIiifSelectors((target as Record<string, any>).selector)
+            : [];
+    const xywh =
+        findSelectorXywh(selectors) ||
+        (targetId ? parseIiifXywh(targetId) : null);
+
+    return [
+        {
+            raw: target,
+            targetId,
+            canvasId: targetId ? getIiifCanvasId(targetId) : null,
+            selectors,
+            xywh,
+        },
+    ];
+}

--- a/src/lib/utils/resolveCanvasImage.ts
+++ b/src/lib/utils/resolveCanvasImage.ts
@@ -1,6 +1,7 @@
 import { getVisibleCanvasEntries } from '../components/viewerControls';
 import { getCanvasLabel } from './canvasLabels';
 import { getCanvasId, getResourceId } from './iiifIds';
+import { normalizeIiifTargets } from './iiifTargets';
 
 export type TileSource = string | { type: 'image'; url: string };
 
@@ -186,19 +187,17 @@ function parseTargetRegion(annotation: any): {
     width: number;
     height: number;
 } | null {
-    const target = annotation?.target || annotation?.__jsonld?.target;
-    const targetId =
-        (typeof target === 'string' ? target : target?.id || target?.['@id']) ||
-        '';
-    const xywhMatch = targetId.match(/#xywh=(\d+),(\d+),(\d+),(\d+)/);
+    const region = normalizeIiifTargets(
+        annotation?.target || annotation?.__jsonld?.target,
+    ).find((target) => target.xywh)?.xywh;
 
-    if (!xywhMatch) return null;
+    if (!region) return null;
 
     return {
-        x: Number(xywhMatch[1]),
-        y: Number(xywhMatch[2]),
-        width: Number(xywhMatch[3]),
-        height: Number(xywhMatch[4]),
+        x: region[0],
+        y: region[1],
+        width: region[2],
+        height: region[3],
     };
 }
 
@@ -316,7 +315,9 @@ function getAnnotationResource(
                 const items = body.items || body.item || [];
                 const selectedId = getSelectedChoice?.(canvasId);
                 const selectedItem = selectedId
-                    ? items.find((item: any) => getResourceId(item) === selectedId)
+                    ? items.find(
+                          (item: any) => getResourceId(item) === selectedId,
+                      )
                     : null;
                 body = selectedItem || items[0] || null;
             }


### PR DESCRIPTION
Clean up five outstanding bugs: 
1. Show collection label (#47)
2. Fix loading first manifest in a collection with wrong viewing direction (#46)
3. Only show canvas metadata button when there is additional info and also make it stand out a little more (#45)
4. Normalized image sizes for paged and continuous behaviors (#44)
5. Fix line from annotation label to annoation on canvas so it always attaches to the "inside" side of the label (#43).