### PR TITLE
Fix CI: bump node to 24, repair stale MetadataPanel test mock

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '24'
                   cache: 'pnpm'
 
             - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
                   version: 9
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 24
             - name: Update npm
               run: npm install -g npm@latest
             - run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '24'
                   cache: 'pnpm'
 
             - name: Install dependencies

--- a/src/lib/components/MetadataPanelTestHost.svelte
+++ b/src/lib/components/MetadataPanelTestHost.svelte
@@ -21,7 +21,7 @@
             return {
                 __jsonld: manifest,
                 getLabel: () => manifest.label,
-                getDescription: () => '',
+                getDescription: () => ({ getValue: () => '' }),
                 getRequiredStatement: () => null,
                 getLicense: () => '',
             };


### PR DESCRIPTION
## Fixes three failing workflows on `main` (commit 518c3e0)

### Run Tests — `MetadataPanel.test.ts`
`MetadataPanelTestHost` mocked `getDescription()` as a bare string `''`, but manifesto's `IIIFResource.getDescription()` returns a `PropertyValue`. The v2-manifest fix in 518c3e0 calls `.getValue()` on the result — and `''?.getValue()` does **not** short-circuit (an empty string isn't nullish), so it threw `getValue is not a function`. Production code is correct against the real API; the mock was stale. It now returns a `PropertyValue`-shaped object.

### Release & Documentation
Both runners used node 20:
- `build:lib` runs `src/packaging/pruneDist.ts` directly with `node`, which needs type-stripping (node ≥22).
- `npm install -g npm@latest` now pulls npm@12, which requires node `^22.22.2 || ^24.15.0 || >=26`.

Bumped all three workflows to node 24 (matches local dev environment).

## Verification
- `MetadataPanel.test.ts` passes locally.
- `node ./src/packaging/pruneDist.ts` runs clean under node 24.